### PR TITLE
Solve bug when generating OpticalPhoton

### DIFF
--- a/src/WCSimStackingAction.cc
+++ b/src/WCSimStackingAction.cc
@@ -48,7 +48,7 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
 	// XQ: get the maximum QE and multiply it by the ratio
 	// only work for the range between 240 nm and 660 nm for now 
 	// Even with WLS
-	G4String volumeName        = aTrack->GetVolume()->GetName();
+	//G4String volumeName        = aTrack->GetVolume()->GetName();
 
 	if (DetConstruct->GetPMT_QE_Method()==1){
 	  wavelengthQE  = DetConstruct->GetPMTQE(WCIDCollectionName,photonWavelength,1,240,660,ratio);


### PR DESCRIPTION
For some reason it seems when we generate Optical Photon in the PrimaryAction, they don't have a Volume (this maybe a bug by itself, it should be investigated). 

In Staking Action, when there is an Optical Photon, the Volume name is check but does nothing. In case of Primary optical photon this causes a crash. I propose to comment this line to avoid the crash. 

Check whether the absence of volume for Primary Optical photon should be done too.