### PR TITLE
Add extra tracking information, etc., from nuPRISM/WCSim fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ ADD_CUSTOM_TARGET(LinkDirectories ALL
 		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/src 		${CMAKE_CURRENT_BINARY_DIR}/src)
 
 
-## WCSimRootDict.cc regeneration by rootcint
+## WCSimRootDict.cxx regeneration by rootcint
 ## Use ROOT 5.34.32 as some issues with PARSE_ARGUMENTS were found in older ROOT versions (ROOT 5.34.11)
 if ( ${ROOT_VERSION} GREATER_EQUAL 6 )
 	# ROOT6 doesn't accept '/' in target and header names, use include_directories instead 
@@ -60,14 +60,9 @@ if ( ${ROOT_VERSION} GREATER_EQUAL 6 )
 			WCSimRootTools.hh 
 			LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
 	
-	# Move ROOTDict in src directory
-	ADD_CUSTOM_COMMAND(OUTPUT ./src/WCSimRootDict.cxx
-			COMMAND ${CMAKE_COMMAND} -E copy WCSimRootDict.cxx 		${CMAKE_CURRENT_SOURCE_DIR}/src/WCSimRootDict.cxx 
-			COMMAND ${CMAKE_COMMAND} -E remove WCSimRootDict.cxx
-			MAIN_DEPENDENCY WCSimRootDict.cxx )
 else()
 	# ROOT5 need the full path
-	ROOT_GENERATE_DICTIONARY(${CMAKE_CURRENT_SOURCE_DIR}/src/WCSimRootDict 
+	ROOT_GENERATE_DICTIONARY(WCSimRootDict 
 			${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootEvent.hh 
 			${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootGeom.hh 
 			${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimPmtInfo.hh 
@@ -93,7 +88,7 @@ add_library(WCSimRoot SHARED
 		./src/TJNuBeamFlux.cc 
 		./src/TNRooTrackerVtx.cc 
 		./src/WCSimRootTools.cc 
-		./src/WCSimRootDict.cxx)
+		WCSimRootDict.cxx)
 target_link_libraries(WCSimRoot  ${ROOT_LIBRARIES})
 
 # Create libWCSimRootDict.so (needed for ROOT6)
@@ -148,7 +143,7 @@ else()
 endif()
 
 # Set flag for git version to be used as c++ preprocessor macro
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`git describe --always --long --tags --dirty`\\\"\"")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`cd ${PROJECT_SOURCE_DIR};git describe --always --long --tags --dirty`\\\"\"")
 
 add_executable(WCSim WCSim.cc ${sources} ${headers})
 target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree)  #add profiler to use gperftools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,8 @@ else()
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()
 
-
+# Set flag for git version to be used as c++ preprocessor macro
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`git describe --always --long --tags --dirty`\\\"\"")
 
 add_executable(WCSim WCSim.cc ${sources} ${headers})
 target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree)  #add profiler to use gperftools

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -49,6 +49,9 @@ else
 DOXYGEN_EXISTS = 0
 endif
 
+# Set flag for git version to be used as c++ preprocessor macro
+CPPFLAGS += -DGIT_HASH=\"$(shell git describe --always --long --tags --dirty)\"
+
 .PHONY: all
 all: rootcint lib bin shared libWCSim.a movedict
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -11,6 +11,7 @@
 #include "TClonesArray.h"
 #include <string>
 #include <vector>
+#include "TVector3.h"
 //#include <map>
 //#include "G4Transform3D.hh"
 
@@ -114,15 +115,21 @@ private:
   // See jhfNtuple.h for the meaning of these data members:
   Double_t fTruetime;
   Int_t   fPrimaryParentID;
+  Float_t fPhotonStartTime;
+  Float_t fPhotonStartPos[3];
 
 public:
   WCSimRootCherenkovHitTime() {}
   WCSimRootCherenkovHitTime(Double_t truetime,
-			    Int_t   primaryParentID);
+			    Int_t   primaryParentID,
+			    Float_t photonStartTime,
+			    Float_t photonStartPos[3]);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Double_t   GetTruetime() { return fTruetime;}
   Int_t     GetParentID() { return fPrimaryParentID;}
+  Float_t   GetPhotonStartTime() { return fPhotonStartTime; }
+  Float_t   GetPhotonStartPos(int i) { return (i<3) ? fPhotonStartPos[i] : 0; }
 
   ClassDef(WCSimRootCherenkovHitTime,1)  
 };
@@ -401,7 +408,9 @@ public:
 					   Int_t                mPMTID,
 					   Int_t                mPMT_PMTID,
 					  std::vector<Double_t> truetime,
-					  std::vector<Int_t>   primParID);
+					  std::vector<Int_t>   primParID,
+					  std::vector<Float_t>   photonStartTime,
+					  std::vector<TVector3>   photonStartPos);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -118,6 +118,8 @@ private:
   Float_t fPhotonStartTime;
   Float_t fPhotonStartPos[3];
   Float_t fPhotonEndPos[3];
+  Float_t fPhotonStartDir[3];
+  Float_t fPhotonEndDir[3];
 
 public:
   WCSimRootCherenkovHitTime() {}
@@ -125,7 +127,9 @@ public:
 			    Int_t   primaryParentID,
 			    Float_t photonStartTime,
 			    Float_t photonStartPos[3],
-			    Float_t photonEndPos[3]);
+			    Float_t photonEndPos[3],
+			    Float_t photonStartDir[3],
+			    Float_t photonEndDir[3]);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Double_t   GetTruetime() { return fTruetime;}
@@ -133,6 +137,8 @@ public:
   Float_t   GetPhotonStartTime() { return fPhotonStartTime; }
   Float_t   GetPhotonStartPos(int i) { return (i<3) ? fPhotonStartPos[i] : 0; }
   Float_t   GetPhotonEndPos(int i) { return (i<3) ? fPhotonEndPos[i] : 0; }
+  Float_t   GetPhotonStartDir(int i) { return (i<3) ? fPhotonStartDir[i] : 0; }
+  Float_t   GetPhotonEndDir(int i) { return (i<3) ? fPhotonEndDir[i] : 0; }
 
   ClassDef(WCSimRootCherenkovHitTime,1)  
 };
@@ -414,7 +420,9 @@ public:
 					  std::vector<Int_t>   primParID,
 					  std::vector<Float_t>   photonStartTime,
 					  std::vector<TVector3>   photonStartPos,
-					  std::vector<TVector3>   photonEndPos);
+					  std::vector<TVector3>   photonEndPos,
+					  std::vector<TVector3>   photonStartDir,
+					  std::vector<TVector3>   photonEndDir);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -117,19 +117,22 @@ private:
   Int_t   fPrimaryParentID;
   Float_t fPhotonStartTime;
   Float_t fPhotonStartPos[3];
+  Float_t fPhotonEndPos[3];
 
 public:
   WCSimRootCherenkovHitTime() {}
   WCSimRootCherenkovHitTime(Double_t truetime,
 			    Int_t   primaryParentID,
 			    Float_t photonStartTime,
-			    Float_t photonStartPos[3]);
+			    Float_t photonStartPos[3],
+			    Float_t photonEndPos[3]);
   virtual ~WCSimRootCherenkovHitTime() { }
 
   Double_t   GetTruetime() { return fTruetime;}
   Int_t     GetParentID() { return fPrimaryParentID;}
   Float_t   GetPhotonStartTime() { return fPhotonStartTime; }
   Float_t   GetPhotonStartPos(int i) { return (i<3) ? fPhotonStartPos[i] : 0; }
+  Float_t   GetPhotonEndPos(int i) { return (i<3) ? fPhotonEndPos[i] : 0; }
 
   ClassDef(WCSimRootCherenkovHitTime,1)  
 };
@@ -410,7 +413,8 @@ public:
 					  std::vector<Double_t> truetime,
 					  std::vector<Int_t>   primParID,
 					  std::vector<Float_t>   photonStartTime,
-					  std::vector<TVector3>   photonStartPos);
+					  std::vector<TVector3>   photonStartPos,
+					  std::vector<TVector3>   photonEndPos);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
 

--- a/include/WCSimTrackInformation.hh
+++ b/include/WCSimTrackInformation.hh
@@ -15,13 +15,19 @@
 // electrons from pion decay are very relevant!!
 class WCSimTrackInformation : public G4VUserTrackInformation {
 private:
-  G4bool saveit; 
+  G4bool saveit;
   G4int  primaryParentID;
+  G4float  photonStartTime;
+  G4ThreeVector  photonStartPos;
 
 public:
   WCSimTrackInformation() : saveit(false), primaryParentID(-99) {}  //TF: initialize to value with NO meaning instead of DN
-  WCSimTrackInformation(const WCSimTrackInformation* aninfo) 
-  { saveit = aninfo->saveit; primaryParentID = aninfo->primaryParentID;}
+  WCSimTrackInformation(const WCSimTrackInformation* aninfo) {
+      saveit = aninfo->saveit;
+      primaryParentID = aninfo->primaryParentID;
+      photonStartTime = aninfo->photonStartTime;
+      photonStartPos = aninfo->photonStartPos;
+  }
   virtual ~WCSimTrackInformation() {}
   WCSimTrackInformation(const G4Track* );
   
@@ -29,7 +35,11 @@ public:
   void WillBeSaved(G4bool choice) { saveit = choice;}
 
   void SetPrimaryParentID(G4int i) { primaryParentID = i;}
+  void SetPhotonStartTime(G4float time) { photonStartTime = time;}
+  void SetPhotonStartPos(const G4ThreeVector &pos) { photonStartPos = pos;}
   G4int GetPrimaryParentID() {return primaryParentID;}
+  G4float GetPhotonStartTime() {return photonStartTime;}
+  G4ThreeVector GetPhotonStartPos() {return photonStartPos;}
 
   inline void *operator new(size_t);
   inline void operator delete(void *aTrackInfo);

--- a/include/WCSimTrackInformation.hh
+++ b/include/WCSimTrackInformation.hh
@@ -19,6 +19,7 @@ private:
   G4int  primaryParentID;
   G4float  photonStartTime;
   G4ThreeVector  photonStartPos;
+  G4ThreeVector  photonStartDir;
 
 public:
   WCSimTrackInformation() : saveit(false), primaryParentID(-99) {}  //TF: initialize to value with NO meaning instead of DN
@@ -27,6 +28,7 @@ public:
       primaryParentID = aninfo->primaryParentID;
       photonStartTime = aninfo->photonStartTime;
       photonStartPos = aninfo->photonStartPos;
+      photonStartDir = aninfo->photonStartDir;
   }
   virtual ~WCSimTrackInformation() {}
   WCSimTrackInformation(const G4Track* );
@@ -37,9 +39,11 @@ public:
   void SetPrimaryParentID(G4int i) { primaryParentID = i;}
   void SetPhotonStartTime(G4float time) { photonStartTime = time;}
   void SetPhotonStartPos(const G4ThreeVector &pos) { photonStartPos = pos;}
+  void SetPhotonStartDir(const G4ThreeVector &dir) { photonStartDir = dir;}
   G4int GetPrimaryParentID() {return primaryParentID;}
   G4float GetPhotonStartTime() {return photonStartTime;}
   G4ThreeVector GetPhotonStartPos() {return photonStartPos;}
+  G4ThreeVector GetPhotonStartDir() {return photonStartDir;}
 
   inline void *operator new(size_t);
   inline void operator delete(void *aTrackInfo);

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -162,6 +162,7 @@ public:
     int index_primaryparentid;
     float index_photonstarttime;
     G4ThreeVector index_photonstartpos;
+    G4ThreeVector index_photonendpos;
     for (i = 1; i < (int) time.size(); ++i)
       {
         index_time  = time[i];
@@ -171,6 +172,7 @@ public:
 	index_primaryparentid = primaryParentID[i];
 	index_photonstarttime = photonStartTime[i];
 	index_photonstartpos = photonStartPos[i];
+	index_photonendpos = photonEndPos[i];
         for (j = i; j > 0 && time[j-1] > index_time; j--) {
           time[j] = time[j-1];
           pe[j] = pe[j-1];
@@ -178,6 +180,7 @@ public:
 	  primaryParentID[j] = primaryParentID[j-1];
 	  photonStartTime[j] = photonStartTime[j-1];
 	  photonStartPos[j] = photonStartPos[j-1];
+	  photonEndPos[j] = photonEndPos[j-1];
           //G4cout <<"swapping "<<time[j-1]<<" "<<index_time<<G4endl;
         }
         
@@ -188,6 +191,7 @@ public:
 	primaryParentID[j] = index_primaryparentid;
 	photonStartTime[j] = index_photonstarttime;
 	photonStartPos[j] = index_photonstartpos;
+	photonEndPos[j] = index_photonendpos;
       }    
   }
   

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -157,6 +157,8 @@ public:
     double index_time,index_timepresmear,index_pe;
     std::vector<int> index_digicomp;
     int index_primaryparentid;
+    float index_photonstarttime;
+    G4ThreeVector index_photonstartpos;
     for (i = 1; i < (int) time.size(); ++i)
       {
         index_time  = time[i];
@@ -164,11 +166,15 @@ public:
         index_pe = pe[i];
 	index_digicomp = fDigiComp[i];
 	index_primaryparentid = primaryParentID[i];
+	index_photonstarttime = photonStartTime[i];
+	index_photonstartpos = photonStartPos[i];
         for (j = i; j > 0 && time[j-1] > index_time; j--) {
           time[j] = time[j-1];
           pe[j] = pe[j-1];
 	  fDigiComp[j] = fDigiComp[j-1];
 	  primaryParentID[j] = primaryParentID[j-1];
+	  photonStartTime[j] = photonStartTime[j-1];
+	  photonStartPos[j] = photonStartPos[j-1];
           //G4cout <<"swapping "<<time[j-1]<<" "<<index_time<<G4endl;
         }
         
@@ -177,6 +183,8 @@ public:
         pe[j] = index_pe;
 	fDigiComp[j] = index_digicomp;
 	primaryParentID[j] = index_primaryparentid;
+	photonStartTime[j] = index_photonstarttime;
+	photonStartPos[j] = index_photonstartpos;
       }    
   }
   

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -71,7 +71,8 @@ private:
   std::map<int, std::vector<int> > fDigiComp;
   std::map<int, G4int>    primaryParentID; ///< Primary parent ID of the Hit (do not use for Digits)
   std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
-  std::map<int, G4ThreeVector>    photonStartPos; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonStartPos; ///< Start point of the photon of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonEndPos; ///< End point of the photon of the Hit (do not use for Digits)
   
 
   //integrated hit/digit parameters
@@ -95,6 +96,7 @@ public:
   inline void SetParentID(G4int gate, G4int parent) { primaryParentID[gate] = parent; };
   inline void SetPhotonStartTime(G4int gate, G4float time) { photonStartTime[gate] = time; };
   inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
+  inline void SetPhotonEndPos(G4int gate, const G4ThreeVector &position) { photonEndPos[gate] = position; };
 
   // Add a digit number and unique photon number to fDigiComp
   inline void AddPhotonToDigiComposition(int digi_number, int photon_number){
@@ -111,6 +113,7 @@ public:
   inline G4int          GetParentID(int gate)    { return primaryParentID[gate];};
   inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
   inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
+  inline G4ThreeVector  GetPhotonEndPos(int gate)    { return photonEndPos[gate];};
   inline G4int          GetTrackID()    { return trackID;};
   inline G4double GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -70,6 +70,8 @@ private:
    */
   std::map<int, std::vector<int> > fDigiComp;
   std::map<int, G4int>    primaryParentID; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonStartPos; ///< Primary parent ID of the Hit (do not use for Digits)
   
 
   //integrated hit/digit parameters
@@ -91,6 +93,8 @@ public:
   inline void SetTime(G4int gate, G4double T)    {time[gate]   = T;};
   inline void SetPreSmearTime(G4int gate, G4double T)    {time_presmear[gate]   = T;};
   inline void SetParentID(G4int gate, G4int parent) { primaryParentID[gate] = parent; };
+  inline void SetPhotonStartTime(G4int gate, G4float time) { photonStartTime[gate] = time; };
+  inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
 
   // Add a digit number and unique photon number to fDigiComp
   inline void AddPhotonToDigiComposition(int digi_number, int photon_number){
@@ -105,6 +109,8 @@ public:
 
 
   inline G4int          GetParentID(int gate)    { return primaryParentID[gate];};
+  inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
+  inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
   inline G4int          GetTrackID()    { return trackID;};
   inline G4double GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -73,6 +73,8 @@ private:
   std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonStartPos; ///< Start point of the photon of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonEndPos; ///< End point of the photon of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonStartDir; ///< Start dir of the photon of the Hit (do not use for Digits)
+  std::map<int, G4ThreeVector>    photonEndDir; ///< End dir of the photon of the Hit (do not use for Digits)
   
 
   //integrated hit/digit parameters
@@ -97,6 +99,8 @@ public:
   inline void SetPhotonStartTime(G4int gate, G4float time) { photonStartTime[gate] = time; };
   inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
   inline void SetPhotonEndPos(G4int gate, const G4ThreeVector &position) { photonEndPos[gate] = position; };
+  inline void SetPhotonStartDir(G4int gate, const G4ThreeVector &direction) { photonStartDir[gate] = direction; };
+  inline void SetPhotonEndDir(G4int gate, const G4ThreeVector &direction) { photonEndDir[gate] = direction; };
 
   // Add a digit number and unique photon number to fDigiComp
   inline void AddPhotonToDigiComposition(int digi_number, int photon_number){
@@ -114,6 +118,8 @@ public:
   inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
   inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
   inline G4ThreeVector  GetPhotonEndPos(int gate)    { return photonEndPos[gate];};
+  inline G4ThreeVector  GetPhotonStartDir(int gate)    { return photonStartDir[gate];};
+  inline G4ThreeVector  GetPhotonEndDir(int gate)    { return photonEndDir[gate];};
   inline G4int          GetTrackID()    { return trackID;};
   inline G4double GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};
@@ -163,6 +169,8 @@ public:
     float index_photonstarttime;
     G4ThreeVector index_photonstartpos;
     G4ThreeVector index_photonendpos;
+    G4ThreeVector index_photonstartdir;
+    G4ThreeVector index_photonenddir;
     for (i = 1; i < (int) time.size(); ++i)
       {
         index_time  = time[i];
@@ -173,6 +181,8 @@ public:
 	index_photonstarttime = photonStartTime[i];
 	index_photonstartpos = photonStartPos[i];
 	index_photonendpos = photonEndPos[i];
+	index_photonstartdir = photonStartDir[i];
+	index_photonenddir = photonEndDir[i];
         for (j = i; j > 0 && time[j-1] > index_time; j--) {
           time[j] = time[j-1];
           pe[j] = pe[j-1];
@@ -181,6 +191,8 @@ public:
 	  photonStartTime[j] = photonStartTime[j-1];
 	  photonStartPos[j] = photonStartPos[j-1];
 	  photonEndPos[j] = photonEndPos[j-1];
+	  photonStartDir[j] = photonStartDir[j-1];
+	  photonEndDir[j] = photonEndDir[j-1];
           //G4cout <<"swapping "<<time[j-1]<<" "<<index_time<<G4endl;
         }
         
@@ -192,6 +204,8 @@ public:
 	photonStartTime[j] = index_photonstarttime;
 	photonStartPos[j] = index_photonstartpos;
 	photonEndPos[j] = index_photonendpos;
+	photonStartDir[j] = index_photonstartdir;
+	photonEndDir[j] = index_photonenddir;
       }    
   }
   

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -62,8 +62,9 @@ class WCSimWCHit : public G4VHit
   void SetOrientation  (G4ThreeVector xyz)          { orient = xyz; };
   void SetRot          (G4RotationMatrix rotMatrix) { rot = rotMatrix; };
   void SetLogicalVolume(G4LogicalVolume* logV)      { pLogV = logV;}
-  void AddParentID     (G4int primParentID)
-  { primaryParentID.push_back(primParentID); }
+  void AddParentID     (G4int primParentID) { primaryParentID.push_back(primParentID); }
+  void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
+  void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }
   void SetTubeType     (G4String tube_type)          { tubeType = tube_type; }; //Added by B.Quilain to transmit on which PMT type the hit happened. For detectors with several PMT types in ID.
 
   
@@ -89,6 +90,8 @@ class WCSimWCHit : public G4VHit
   G4double      GetTime(int i)  { return time[i];};
   G4int         GetParentID(int i) { return primaryParentID[i];};
   G4String         GetTubeType()     { return tubeType; };
+  G4float       GetPhotonStartTime(int i) { return photonStartTime[i];};
+  G4ThreeVector GetPhotonStartPos(int i) { return photonStartPos[i];};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -172,6 +175,8 @@ class WCSimWCHit : public G4VHit
   G4int                 totalPe;
   std::vector<G4double> time;
   std::vector<G4int>    primaryParentID;
+  std::vector<G4float>  photonStartTime;
+  std::vector<G4ThreeVector> photonStartPos;
   G4int                 totalPeInGate;
 };
 

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -66,6 +66,8 @@ class WCSimWCHit : public G4VHit
   void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
   void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }
   void AddPhotonEndPos  (const G4ThreeVector &photEndPos) { photonEndPos.push_back(photEndPos); }
+  void AddPhotonStartDir  (const G4ThreeVector &photStartDir) { photonStartDir.push_back(photStartDir); }
+  void AddPhotonEndDir  (const G4ThreeVector &photEndDir) { photonEndDir.push_back(photEndDir); }
   void SetTubeType     (G4String tube_type)          { tubeType = tube_type; }; //Added by B.Quilain to transmit on which PMT type the hit happened. For detectors with several PMT types in ID.
 
   
@@ -94,6 +96,8 @@ class WCSimWCHit : public G4VHit
   G4float       GetPhotonStartTime(int i) { return photonStartTime[i];};
   G4ThreeVector GetPhotonStartPos(int i) { return photonStartPos[i];};
   G4ThreeVector GetPhotonEndPos(int i) { return photonEndPos[i];};
+  G4ThreeVector GetPhotonStartDir(int i) { return photonStartDir[i];};
+  G4ThreeVector GetPhotonEndDir(int i) { return photonEndDir[i];};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -180,6 +184,8 @@ class WCSimWCHit : public G4VHit
   std::vector<G4float>  photonStartTime;
   std::vector<G4ThreeVector> photonStartPos;
   std::vector<G4ThreeVector> photonEndPos;
+  std::vector<G4ThreeVector> photonStartDir;
+  std::vector<G4ThreeVector> photonEndDir;
   G4int                 totalPeInGate;
 };
 

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -65,6 +65,7 @@ class WCSimWCHit : public G4VHit
   void AddParentID     (G4int primParentID) { primaryParentID.push_back(primParentID); }
   void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
   void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }
+  void AddPhotonEndPos  (const G4ThreeVector &photEndPos) { photonEndPos.push_back(photEndPos); }
   void SetTubeType     (G4String tube_type)          { tubeType = tube_type; }; //Added by B.Quilain to transmit on which PMT type the hit happened. For detectors with several PMT types in ID.
 
   
@@ -92,6 +93,7 @@ class WCSimWCHit : public G4VHit
   G4String         GetTubeType()     { return tubeType; };
   G4float       GetPhotonStartTime(int i) { return photonStartTime[i];};
   G4ThreeVector GetPhotonStartPos(int i) { return photonStartPos[i];};
+  G4ThreeVector GetPhotonEndPos(int i) { return photonEndPos[i];};
   
   G4LogicalVolume* GetLogicalVolume() {return pLogV;};
 
@@ -177,6 +179,7 @@ class WCSimWCHit : public G4VHit
   std::vector<G4int>    primaryParentID;
   std::vector<G4float>  photonStartTime;
   std::vector<G4ThreeVector> photonStartPos;
+  std::vector<G4ThreeVector> photonEndPos;
   G4int                 totalPeInGate;
 };
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -323,6 +323,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 	(*WCHC)[hitIndex]->AddPe(time);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
 	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
+	(*WCHC)[hitIndex]->AddPhotonEndPos(pos);
 	(*WCHC)[hitIndex]->AddPhotonStartTime(time);
       }
 
@@ -1170,10 +1171,12 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     std::vector<int>   primaryParentID;
     std::vector<float> photonStartTime;
     std::vector<TVector3> photonStartPos;
+    std::vector<TVector3> photonEndPos;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
     float hit_photon_starttime;
     TVector3 hit_photon_startpos;
+    TVector3 hit_photon_endpos;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -1187,10 +1190,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[0], 
 	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[1], 
 	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[2]);
+	hit_photon_endpos = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
 	photonStartTime.push_back(hit_photon_starttime);
 	photonStartPos.push_back(hit_photon_startpos);
+	photonEndPos.push_back(hit_photon_endpos);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -1215,12 +1223,14 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				      truetime,
 				      primaryParentID,
 				      photonStartTime,
-				      photonStartPos);
+				      photonStartPos,
+				      photonEndPos);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
       photonStartTime.clear();
       photonStartPos.clear();
+      photonEndPos.clear();
     }//idigi
   }//if(WCDC_hits)
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -320,10 +320,13 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
       // Ignore logical volume for now...
       for (int pe = 0; pe < nPoisson; pe++) {
 	G4float time = G4RandGauss::shoot(0.0,10.);
+	G4ThreeVector dir(0, 0, 0);
 	(*WCHC)[hitIndex]->AddPe(time);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
 	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
 	(*WCHC)[hitIndex]->AddPhotonEndPos(pos);
+	(*WCHC)[hitIndex]->AddPhotonStartDir(dir);
+	(*WCHC)[hitIndex]->AddPhotonEndDir(dir);
 	(*WCHC)[hitIndex]->AddPhotonStartTime(time);
       }
 
@@ -1172,11 +1175,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     std::vector<float> photonStartTime;
     std::vector<TVector3> photonStartPos;
     std::vector<TVector3> photonEndPos;
+    std::vector<TVector3> photonStartDir;
+    std::vector<TVector3> photonEndDir;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
     float hit_photon_starttime;
     TVector3 hit_photon_startpos;
     TVector3 hit_photon_endpos;
+    TVector3 hit_photon_startdir;
+    TVector3 hit_photon_enddir;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -1194,11 +1201,21 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[0],
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[1],
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[2]);
+	hit_photon_startdir = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[0], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[1], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[2]);
+	hit_photon_enddir = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
 	photonStartTime.push_back(hit_photon_starttime);
 	photonStartPos.push_back(hit_photon_startpos);
 	photonEndPos.push_back(hit_photon_endpos);
+	photonStartDir.push_back(hit_photon_startdir);
+	photonEndDir.push_back(hit_photon_enddir);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -1224,13 +1241,17 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				      primaryParentID,
 				      photonStartTime,
 				      photonStartPos,
-				      photonEndPos);
+				      photonEndPos,
+				      photonStartDir,
+				      photonEndDir);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
       photonStartTime.clear();
       photonStartPos.clear();
       photonEndPos.clear();
+      photonStartDir.clear();
+      photonEndDir.clear();
     }//idigi
   }//if(WCDC_hits)
 
@@ -1663,11 +1684,15 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
     std::vector<float> photonStartTime;
     std::vector<TVector3> photonStartPos;
     std::vector<TVector3> photonEndPos;
+    std::vector<TVector3> photonStartDir;
+    std::vector<TVector3> photonEndDir;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
     float hit_photon_starttime;
     TVector3 hit_photon_startpos;
     TVector3 hit_photon_endpos;
+    TVector3 hit_photon_startdir;
+    TVector3 hit_photon_enddir;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -1685,11 +1710,21 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[0],
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[1],
 	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[2]);
+	hit_photon_startdir = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonStartDir(id)[2]);
+	hit_photon_enddir = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonEndDir(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
 	photonStartTime.push_back(hit_photon_starttime);
 	photonStartPos.push_back(hit_photon_startpos);
 	photonEndPos.push_back(hit_photon_endpos);
+	photonStartDir.push_back(hit_photon_startdir);
+	photonEndDir.push_back(hit_photon_enddir);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -1715,13 +1750,17 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 				      primaryParentID,
 				      photonStartTime,
 				      photonStartPos,
-				      photonEndPos);
+				      photonEndPos,
+				      photonStartDir,
+				      photonEndDir);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
       photonStartTime.clear();
       photonStartPos.clear();
       photonEndPos.clear();
+      photonStartDir.clear();
+      photonEndDir.clear();
     }//idigi 
   }//if(WCDC_hits)
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -310,16 +310,20 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 	
       }
      
+      const G4ThreeVector &pos = detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getTranslation();
       (*WCHC)[hitIndex]->SetTubeID((*pmtIt)->Get_tubeid());
       (*WCHC)[hitIndex]->SetTrackID(0);
       (*WCHC)[hitIndex]->SetEdep(0.);
-      (*WCHC)[hitIndex]->SetPos(detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getTranslation());
+      (*WCHC)[hitIndex]->SetPos(pos);
       (*WCHC)[hitIndex]->SetRot(detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getRotation());
       
       // Ignore logical volume for now...
       for (int pe = 0; pe < nPoisson; pe++) {
-	(*WCHC)[hitIndex]->AddPe(G4RandGauss::shoot(0.0,10.));
+	G4float time = G4RandGauss::shoot(0.0,10.);
+	(*WCHC)[hitIndex]->AddPe(time);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
+	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
+	(*WCHC)[hitIndex]->AddPhotonStartTime(time);
       }
 
       G4cout << "The option using pmtPoisson is not implemented for the hybrid version yet." << G4endl;
@@ -1164,8 +1168,12 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     wcsimrootevent->SetNumTubesHit(WCDC_hits->entries());
     std::vector<double> truetime, smeartime;
     std::vector<int>   primaryParentID;
+    std::vector<float> photonStartTime;
+    std::vector<TVector3> photonStartPos;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
+    float hit_photon_starttime;
+    TVector3 hit_photon_startpos;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -1174,8 +1182,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
+	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);
+	hit_photon_startpos = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[0], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[1], 
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
+	photonStartTime.push_back(hit_photon_starttime);
+	photonStartPos.push_back(hit_photon_startpos);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -1198,11 +1213,15 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				      pmt->Get_mPMTid(),
 				      pmt->Get_mPMT_pmtid(),
 				      truetime,
-				      primaryParentID);
+				      primaryParentID,
+				      photonStartTime,
+				      photonStartPos);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
-    }//idigi 
+      photonStartTime.clear();
+      photonStartPos.clear();
+    }//idigi
   }//if(WCDC_hits)
 
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1660,8 +1660,14 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
     wcsimrootevent->SetNumTubesHit(WCDC_hits->entries());
     std::vector<double> truetime, smeartime;
     std::vector<int>   primaryParentID;
+    std::vector<float> photonStartTime;
+    std::vector<TVector3> photonStartPos;
+    std::vector<TVector3> photonEndPos;
     double hit_time_smear, hit_time_true;
     int hit_parentid;
+    float hit_photon_starttime;
+    TVector3 hit_photon_startpos;
+    TVector3 hit_photon_endpos;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
@@ -1670,8 +1676,20 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
+	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);
+	hit_photon_startpos = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonStartPos(id)[2]);
+	hit_photon_endpos = TVector3(
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[0],
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[1],
+	        (*WCDC_hits)[idigi]->GetPhotonEndPos(id)[2]);
 	truetime.push_back(hit_time_true);
 	primaryParentID.push_back(hit_parentid);
+	photonStartTime.push_back(hit_photon_starttime);
+	photonStartPos.push_back(hit_photon_startpos);
+	photonEndPos.push_back(hit_photon_endpos);
 #ifdef _SAVE_RAW_HITS_VERBOSE
 	hit_time_smear = (*WCDC_hits)[idigi]->GetTime(id);
 	smeartime.push_back(hit_time_smear);
@@ -1694,10 +1712,16 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 				      pmt->Get_mPMTid(),
 				      pmt->Get_mPMT_pmtid(),
 				      truetime,
-				      primaryParentID);
+				      primaryParentID,
+				      photonStartTime,
+				      photonStartPos,
+				      photonEndPos);
       smeartime.clear();
       truetime.clear();
       primaryParentID.clear();
+      photonStartTime.clear();
+      photonStartPos.clear();
+      photonEndPos.clear();
     }//idigi 
   }//if(WCDC_hits)
 

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -3062,7 +3062,7 @@ G4double* PMT3inchR14374::GetCollectionEfficiencyArray(){
 G4double PMT3inchR14374::GetDarkRate(){
   // Realistic/Optimistic value from published (proceedings) measurements.
   // ToDo : update this value
-  const G4double rate = 100.*CLHEP::hertz;//100*CLHEP::hertz;
+  const G4double rate = 1000.*CLHEP::hertz;//100*CLHEP::hertz;
   return rate;
 }
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -417,7 +417,9 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
 							 Int_t mPMTID,
 							 Int_t mPMT_PMTID,
 							 std::vector<Double_t> truetime,
-							 std::vector<Int_t> primParID)
+							 std::vector<Int_t> primParID,
+							 std::vector<Float_t> photonStartTime,
+							 std::vector<TVector3> photonStartPos)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -425,9 +427,10 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
   for (unsigned int i =0;i<truetime.size();i++)
   {
     fCherenkovHitCounter++;
-
+    Float_t position[3];
+    for(int j=0; j<3; j++) position[j] = photonStartPos[i][j];
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i]);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], position);
   }
   
 #ifdef DEBUG
@@ -477,11 +480,17 @@ WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
 }
 
 WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
-						     Int_t primParID)
+						     Int_t primParID,
+						     Float_t photonStartTime,
+						     Float_t photonStartPos[3])
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
     fPrimaryParentID = primParID;
+    fPhotonStartTime = photonStartTime;
+    for (int i=0;i<3;i++) {
+        fPhotonStartPos[i] = photonStartPos[i];
+    }
 }
 
 //_____________________________________________________________________________

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -420,7 +420,9 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
 							 std::vector<Int_t> primParID,
 							 std::vector<Float_t> photonStartTime,
 							 std::vector<TVector3> photonStartPos,
-							 std::vector<TVector3> photonEndPos)
+							 std::vector<TVector3> photonEndPos,
+							 std::vector<TVector3> photonStartDir,
+							 std::vector<TVector3> photonEndDir)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -430,12 +432,18 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
     fCherenkovHitCounter++;
     Float_t startPos[3];
     Float_t endPos[3];
+    Float_t startDir[3];
+    Float_t endDir[3];
     for(int j=0; j<3; j++){
       startPos[j] = photonStartPos[i][j];
       endPos[j] = photonEndPos[i][j];
+      startDir[j] = photonStartDir[i][j];
+      endDir[j] = photonEndDir[i][j];
     }
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], startPos, endPos);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i],
+                                                                              photonStartTime[i], startPos, endPos,
+                                                                              startDir, endDir);
   }
   
 #ifdef DEBUG
@@ -488,7 +496,9 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
 						     Int_t primParID,
 						     Float_t photonStartTime,
 						     Float_t photonStartPos[3],
-						     Float_t photonEndPos[3])
+						     Float_t photonEndPos[3],
+						     Float_t photonStartDir[3],
+						     Float_t photonEndDir[3])
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
@@ -497,6 +507,8 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
     for (int i=0;i<3;i++) {
         fPhotonStartPos[i] = photonStartPos[i];
         fPhotonEndPos[i] = photonEndPos[i];
+        fPhotonStartDir[i] = photonStartDir[i];
+        fPhotonEndDir[i] = photonEndDir[i];
     }
 }
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -419,7 +419,8 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
 							 std::vector<Double_t> truetime,
 							 std::vector<Int_t> primParID,
 							 std::vector<Float_t> photonStartTime,
-							 std::vector<TVector3> photonStartPos)
+							 std::vector<TVector3> photonStartPos,
+							 std::vector<TVector3> photonEndPos)
 {
   // Add a new Cherenkov hit to the list of Cherenkov hits
   TClonesArray &cherenkovhittimes = *fCherenkovHitTimes;
@@ -427,10 +428,14 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
   for (unsigned int i =0;i<truetime.size();i++)
   {
     fCherenkovHitCounter++;
-    Float_t position[3];
-    for(int j=0; j<3; j++) position[j] = photonStartPos[i][j];
+    Float_t startPos[3];
+    Float_t endPos[3];
+    for(int j=0; j<3; j++){
+      startPos[j] = photonStartPos[i][j];
+      endPos[j] = photonEndPos[i][j];
+    }
     WCSimRootCherenkovHitTime *cherenkovhittime = 
-      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], position);
+      new(cherenkovhittimes[fNcherenkovhittimes++]) WCSimRootCherenkovHitTime(truetime[i],primParID[i], photonStartTime[i], startPos, endPos);
   }
   
 #ifdef DEBUG
@@ -482,7 +487,8 @@ WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
 WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
 						     Int_t primParID,
 						     Float_t photonStartTime,
-						     Float_t photonStartPos[3])
+						     Float_t photonStartPos[3],
+						     Float_t photonEndPos[3])
 {
   // Create a WCSimRootCherenkovHit object and fill it with stuff
     fTruetime        = truetime; 
@@ -490,6 +496,7 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
     fPhotonStartTime = photonStartTime;
     for (int i=0;i<3;i++) {
         fPhotonStartPos[i] = photonStartPos[i];
+        fPhotonEndPos[i] = photonEndPos[i];
     }
 }
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -85,7 +85,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
     fSettingsOutputTree->Branch("WCDetHeight", &WCDetHeight, "WCDetHeight/D");
 #ifdef GIT_HASH
     const char* gitHash = GIT_HASH;
-    fSettingsOutputTree->Branch("GitHash", (void*)gitHash, "GetHash/C");
+    fSettingsOutputTree->Branch("GitHash", (void*)gitHash, "GitHash/C");
 #endif
   }      
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -83,7 +83,10 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
     fSettingsOutputTree->Branch("WCDetCentre", WCDetCentre, "WCDetCentre[3]/D");
     fSettingsOutputTree->Branch("WCDetRadius", &WCDetRadius, "WCDetRadius/D");
     fSettingsOutputTree->Branch("WCDetHeight", &WCDetHeight, "WCDetHeight/D");
- 
+#ifdef GIT_HASH
+    const char* gitHash = GIT_HASH;
+    fSettingsOutputTree->Branch("GitHash", (void*)gitHash, "GetHash/C");
+#endif
   }      
 
   numberOfEventsGenerated = 0;

--- a/src/WCSimSteppingAction.cc
+++ b/src/WCSimSteppingAction.cc
@@ -61,7 +61,7 @@ void WCSimSteppingAction::UserSteppingAction(const G4Step* aStep)
   }
 
   G4ParticleDefinition *particleType = track->GetDefinition();
-  if(particleType == G4OpticalPhoton::OpticalPhotonDefinition()){
+  if(particleType == G4OpticalPhoton::OpticalPhotonDefinition() && thePrePV && thePostPV){
     if( (thePrePV->GetName().find("MultiPMT") != std::string::npos) &&
 	(thePostPV->GetName().find("vessel") != std::string::npos) )
       n_photons_through_mPMTLV++;

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -172,6 +172,10 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
       for(size_t i=0;i<nSeco;i++)
       { 
 	WCSimTrackInformation* infoSec = new WCSimTrackInformation(anInfo);
+	if(anInfo->isSaved()){ // Parent is primary, so we want start pos & time of this secondary
+		infoSec->SetPhotonStartTime((*secondaries)[i]->GetGlobalTime());
+		infoSec->SetPhotonStartPos((*secondaries)[i]->GetPosition());
+	}
 	infoSec->WillBeSaved(false); // ADDED BY MFECHNER, temporary, 30/8/06
 	(*secondaries)[i]->SetUserInformation(infoSec);
       }

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -28,6 +28,10 @@ WCSimTrackingAction::WCSimTrackingAction()
   ParticleList.insert(311); // kaon0
   ParticleList.insert(-311); // kaon0 bar
   //ParticleList.insert(22); // I add photons (B.Q)
+  ParticleList.insert(11); // e-
+  ParticleList.insert(-11); // e+
+  ParticleList.insert(13); // mu-
+  ParticleList.insert(-13); // mu+
   // don't put gammas there or there'll be too many
 
   //TF: add protons and neutrons

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -179,6 +179,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
 	if(anInfo->isSaved()){ // Parent is primary, so we want start pos & time of this secondary
 		infoSec->SetPhotonStartTime((*secondaries)[i]->GetGlobalTime());
 		infoSec->SetPhotonStartPos((*secondaries)[i]->GetPosition());
+		infoSec->SetPhotonStartDir((*secondaries)[i]->GetMomentumDirection());
 	}
 	infoSec->WillBeSaved(false); // ADDED BY MFECHNER, temporary, 30/8/06
 	(*secondaries)[i]->SetUserInformation(infoSec);

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -278,6 +278,7 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    ahit->SetTime(PMTindex[noise_pmt],current_time);
 	    ahit->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	    ahit->SetPhotonStartPos(PMTindex[noise_pmt], pmt_position);
+	    ahit->SetPhotonEndPos(PMTindex[noise_pmt], pmt_position);
 	    ahit->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	    pe = WCPMT->rn1pe();
 	    ahit->SetPe(PMTindex[noise_pmt],pe);
@@ -301,6 +302,7 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -276,6 +276,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    ahit->SetOrientation(pmt_orientation);
 	    ahit->SetPos(pmt_position);
 	    ahit->SetTime(PMTindex[noise_pmt],current_time);
+	    ahit->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
+	    ahit->SetPhotonStartPos(PMTindex[noise_pmt], pmt_position);
 	    ahit->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	    pe = WCPMT->rn1pe();
 	    ahit->SetPe(PMTindex[noise_pmt],pe);
@@ -297,6 +299,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -279,6 +279,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    ahit->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	    ahit->SetPhotonStartPos(PMTindex[noise_pmt], pmt_position);
 	    ahit->SetPhotonEndPos(PMTindex[noise_pmt], pmt_position);
+	    ahit->SetPhotonStartDir(PMTindex[noise_pmt], -pmt_orientation);
+	    ahit->SetPhotonEndDir(PMTindex[noise_pmt], -pmt_orientation);
 	    ahit->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
 	    pe = WCPMT->rn1pe();
 	    ahit->SetPe(PMTindex[noise_pmt],pe);
@@ -303,6 +305,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartDir(PMTindex[noise_pmt],-(*WCHCPMT)[ list[noise_pmt]-1 ]->GetOrientation());
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndDir(PMTindex[noise_pmt],-(*WCHCPMT)[ list[noise_pmt]-1 ]->GetOrientation());
 	  PMTindex[noise_pmt]++;
 #ifdef WCSIMWCADDDARKNOISE_VERBOSE
 	  if(noise_pmt < NPMTS_VERBOSE)

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -237,6 +237,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	    float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
 	    G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
 	    G4ThreeVector photon_endpos = (*WCHC)[i]->GetPhotonEndPos(ip);
+	    G4ThreeVector photon_startdir = (*WCHC)[i]->GetPhotonStartDir(ip);
+	    G4ThreeVector photon_enddir = (*WCHC)[i]->GetPhotonEndDir(ip);
 	    
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
@@ -254,6 +256,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetPhotonStartTime(ip,photon_starttime);
 	      Digi->SetPhotonStartPos(ip,photon_startpos);
 	      Digi->SetPhotonEndPos(ip,photon_endpos);
+	      Digi->SetPhotonStartDir(ip,photon_startdir);
+	      Digi->SetPhotonEndDir(ip,photon_enddir);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	      bqDigiHitCounter++;
 	    }	
@@ -272,6 +276,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonEndPos(ip,photon_endpos);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartDir(ip,photon_startdir);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonEndDir(ip,photon_enddir);
 	    }
 	    
 	    maxTotalPe = (maxTotalPe < ip) ? ip : maxTotalPe;

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -236,6 +236,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	    
 	    float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
 	    G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
+	    G4ThreeVector photon_endpos = (*WCHC)[i]->GetPhotonEndPos(ip);
 	    
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
@@ -252,6 +253,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetParentID(ip,parent_id);
 	      Digi->SetPhotonStartTime(ip,photon_starttime);
 	      Digi->SetPhotonStartPos(ip,photon_startpos);
+	      Digi->SetPhotonEndPos(ip,photon_endpos);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	      bqDigiHitCounter++;
 	    }	
@@ -269,6 +271,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetParentID(ip,parent_id);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonEndPos(ip,photon_endpos);
 	    }
 	    
 	    maxTotalPe = (maxTotalPe < ip) ? ip : maxTotalPe;

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -234,6 +234,9 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 #endif
 	    QinTOT += Q;
 	    
+	    float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
+	    G4ThreeVector photon_startpos = (*WCHC)[i]->GetPhotonStartPos(ip);
+	    
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
 	      Digi->SetLogicalVolume((*WCHC)[0]->GetLogicalVolume());
@@ -247,6 +250,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetTrackID(track_id);
 	      Digi->SetPreSmearTime(ip,time_true);
 	      Digi->SetParentID(ip,parent_id);
+	      Digi->SetPhotonStartTime(ip,photon_starttime);
+	      Digi->SetPhotonStartPos(ip,photon_startpos);
 	      DigiHitMapPMT[tube] = DigitsCollection->insert(Digi);
 	      bqDigiHitCounter++;
 	    }	
@@ -262,6 +267,8 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTrackID(track_id);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPreSmearTime(ip,time_true);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetParentID(ip,parent_id);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartPos(ip,photon_startpos);
 	    }
 	    
 	    maxTotalPe = (maxTotalPe < ip) ? ip : maxTotalPe;

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -86,16 +86,19 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   G4int primParentID = -1;
   G4float photonStartTime;
   G4ThreeVector photonStartPos;
+  G4ThreeVector photonStartDir;
   if (trackinfo) {
     //Skip secondaries and match to mother process, eg. muon, decay particle, gamma from pi0/nCapture.
     primParentID = trackinfo->GetPrimaryParentID();  //!= ParentID.
     photonStartTime = trackinfo->GetPhotonStartTime();
     photonStartPos = trackinfo->GetPhotonStartPos();
+    photonStartDir = trackinfo->GetPhotonStartDir();
   }
   else { // if there is no trackinfo, then it is a primary particle!
     primParentID = aStep->GetTrack()->GetTrackID();
     photonStartTime = aStep->GetTrack()->GetGlobalTime();
     photonStartPos = aStep->GetTrack()->GetVertexPosition();
+    photonStartDir = aStep->GetTrack()->GetVertexMomentumDirection();
   }
 
 
@@ -244,6 +247,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartDir(photonStartDir);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndDir(worldDirection);
 	   
 	   //     if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition() )
 	   //       newHit->Print();
@@ -255,6 +260,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartDir(photonStartDir);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndDir(worldDirection);
 	 
        }
      }

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -243,6 +243,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
 	   
 	   //     if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition() )
 	   //       newHit->Print();
@@ -253,6 +254,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonEndPos(worldPosition);
 	 
        }
      }

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -84,11 +84,19 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
     = (WCSimTrackInformation*)(aStep->GetTrack()->GetUserInformation());
   
   G4int primParentID = -1;
-  if (trackinfo)
+  G4float photonStartTime;
+  G4ThreeVector photonStartPos;
+  if (trackinfo) {
     //Skip secondaries and match to mother process, eg. muon, decay particle, gamma from pi0/nCapture.
-    primParentID = trackinfo->GetPrimaryParentID();  //!= ParentID. 
-  else // if there is no trackinfo, then it is a primary particle!
-    primParentID = aStep->GetTrack()->GetTrackID();    
+    primParentID = trackinfo->GetPrimaryParentID();  //!= ParentID.
+    photonStartTime = trackinfo->GetPhotonStartTime();
+    photonStartPos = trackinfo->GetPhotonStartPos();
+  }
+  else { // if there is no trackinfo, then it is a primary particle!
+    primParentID = aStep->GetTrack()->GetTrackID();
+    photonStartTime = aStep->GetTrack()->GetGlobalTime();
+    photonStartPos = aStep->GetTrack()->GetVertexPosition();
+  }
 
 
   G4int    trackID           = aStep->GetTrack()->GetTrackID();
@@ -233,6 +241,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   PMTHitMap[replicaNumber] = hitsCollection->insert( newHit );
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
+	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	   
 	   //     if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition() )
 	   //       newHit->Print();
@@ -241,6 +251,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
        else {
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(primParentID);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
+	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
 	 
        }
      }


### PR DESCRIPTION
This pull request has a few changes copied from the latest nuPRISM (IWCD) fork:
- Mostly it is to add tracking of the start time, position & direction and the end position & direction (end time was already tracked) of photons that produce true Cherenkov hits.
- Additionally it stores the git hash at the time of compiling (actually, for CMake, it is at the time of configuring) the WCSim build. This is stored in the root file output, so that you can check exactly which WCSim version was used to produce that root file.
- The default dark rate for PMT3inchR14374 is changed from 100 Hz to 1 kHz. For IWCD we are using this value as a more realistic, conservative value based on tests of the 3" PMTs for mPMTs. Of course this can be changed in the macro file, anyway.
- There is also a change to the CMake build so that the ROOT dictionary is generated in the directory where you are building, instead of copying it there after generating. For me this was necessary when building into a different folder that is not inside the WCSim directory, when using ROOT 5, on the Compute Canada Cedar cluster. It shouldn't break any other environments (tested working for me with both root 5 and root 6).