### PR TITLE
Randomizer initialization

### DIFF
--- a/include/WCSimRandomParameters.hh
+++ b/include/WCSimRandomParameters.hh
@@ -6,6 +6,7 @@
 #include "CLHEP/Random/RanluxEngine.h"
 #include "CLHEP/Random/JamesRandom.h"
 #include "CLHEP/Random/RanecuEngine.h"
+#include "TRandom3.h"
 
 class WCSimRandomParameters
 {
@@ -57,6 +58,7 @@ public:
   void SetSeed(int iseed) 
     { 
       CLHEP::HepRandom::setTheSeed(iseed);
+      gRandom->SetSeed(iseed);
       printf("Setting the Random Seed to: %d\n",iseed); 
       seed = iseed;
     }


### PR DESCRIPTION
I was forgetting to commit this fix, I'm sorry for this. 

The ROOT/CERN Randomizer seed isn't properly initialized, here we set it to be the same value than Geant4's Randomizer seed.