### PR TITLE
Various small building improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-#ignore build results
-src/WCSimRootDict.cc
-src/WCSimRootDict.cxx
-src/WCSimRootDict.h
+# GNU make and CMake in-place build results to ignore
+*WCSimRootDict*
 libWCSim.a
-libWCSimRoot.so
+libWCSimRoot.*
 make.rootcint.result
 make.result
 make.out.txt
@@ -38,7 +36,7 @@ geofile.txt
 ## compiled python scripts to ignore
 *.pyc
 
-##ignore solar 
+## ignore solar 
 data_solar/
 include/WCSimGenerator_Solar.hh
 src/WCSimGenerator_Solar.cc

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # GNU make and CMake in-place build results to ignore
 *WCSimRootDict*
+!src/*WCSimRootDict*
 libWCSim.a
 libWCSimRoot.*
 make.rootcint.result

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ include(${ROOT_USE_FILE})
 # Locate sources and headers for this project
 # ## NOT NEEDED FOR DICT
 include_directories(${PROJECT_SOURCE_DIR}/include 
-                    ${PROJECT_SOURCE_DIR}/../shared/include
                     ${Geant4_INCLUDE_DIR}
                     ${ROOT_INCLUDE_DIRS})
 
@@ -37,11 +36,6 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 # Add libraries: need to compile the Dict before linking WCSim !!
 # in standard makefile, need to make rootcint anyway before standard make
 #
-
-ADD_CUSTOM_TARGET(LinkDirectories ALL
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/include 	${CMAKE_CURRENT_BINARY_DIR}/include
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/src 		${CMAKE_CURRENT_BINARY_DIR}/src)
-
 
 ## WCSimRootDict.cxx regeneration by rootcint
 ## Use ROOT 5.34.32 as some issues with PARSE_ARGUMENTS were found in older ROOT versions (ROOT 5.34.11)
@@ -94,7 +88,7 @@ target_link_libraries(WCSimRoot  ${ROOT_LIBRARIES})
 # Create libWCSimRootDict.so (needed for ROOT6)
 add_custom_command(TARGET WCSimRoot
 		POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.so 	${CMAKE_CURRENT_BINARY_DIR}/libWCSimRootDict.so)
+		COMMAND ${CMAKE_COMMAND} -E create_symlink libWCSimRoot.so libWCSimRootDict.so)
 		
 if ( ${ROOT_VERSION} LESS 6 )
 	# Create Rootmap (not automatically done for ROOT5)
@@ -155,46 +149,35 @@ target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree
 # relies on these files being in the current working directory and then so
 # that we can directly analyze the produced ROOT files, too.
 #
-set(WCSIM_SCRIPTS
-  macros/jobOptions.mac
-  WCSim.mac
-  macros/daq.mac
-  macros/visOGLSX.mac
-  macros/visOGLQT.mac
-  macros/visRayTracer.mac
-  macros/mPMT_nuPrism1.mac
-  macros/mPMT_nuPrism2.mac
-  macros/tuning_parameters.mac
-  macros/NuPRISM.mac
-  macros/mPMT_interesting1.mac
-  macros/mPMT_interesting2_SKwCover.mac
-  macros/mPMT_37pmtHK.mac
-  macros/mPMT_radon_with_bias.mac
-  macros/mPMT_radon_without_bias.mac
-  biasprofile.dat
-  tuningNominal.mac
-  WCSim_hybrid.mac
-  WCSim_hybrid.sh
-  mPMT-configfiles/mPMTconfig_19_nuPrism.txt
-  mPMT-configfiles/mPMTconfig_30_13_3.txt
-  mPMT-configfiles/mPMTconfig_33_50.txt
-  mPMT-configfiles/mPMTconfig_34_22.5_1.txt
-  mPMT-configfiles/mPMTconfig_34_22_1.txt
-  mPMT-configfiles/mPMTconfig_37_HK.txt
-  mPMT-configfiles/mPMTconfig_19_nuPrism_3ring.txt
-  mPMT-configfiles/mPMTconfig_33_13_1.txt
-  mPMT-configfiles/mPMTconfig_33_50_1.txt
-  mPMT-configfiles/mPMTconfig_34_22.5_2.txt
-  mPMT-configfiles/mPMTconfig_34_22_2.txt
-  )
-  
-  foreach(_file ${WCSIM_SCRIPTS})
+if (NOT (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR))
+  file(COPY ${PROJECT_SOURCE_DIR}/mPMT-configfiles DESTINATION ${PROJECT_BINARY_DIR} USE_SOURCE_PERMISSIONS)
+  file(COPY ${PROJECT_SOURCE_DIR}/macros DESTINATION ${PROJECT_BINARY_DIR} USE_SOURCE_PERMISSIONS)
+  # file(COPY ${PROJECT_SOURCE_DIR}/include DESTINATION ${PROJECT_BINARY_DIR} USE_SOURCE_PERMISSIONS)
+  set(WCSIM_FILES
+    WCSim.mac
+    biasprofile.dat
+    tuningNominal.mac
+    WCSim_hybrid.mac
+    WCSim_hybrid.sh
+    include/TJNuBeamFlux.hh
+    include/TNRooTrackerVtx.hh
+    include/WCSimEnumerations.hh
+    include/WCSimPmtInfo.hh
+    include/WCSimRootEvent.hh
+    include/WCSimRootGeom.hh
+    include/WCSimRootOptions.hh
+    include/WCSimRootTools.hh
+    )
+  foreach(_file ${WCSIM_FILES})
     configure_file(
       ${PROJECT_SOURCE_DIR}/${_file}
       ${PROJECT_BINARY_DIR}/${_file}
       COPYONLY
       )
   endforeach()
+else()
+  message(STATUS "Note: building in-place, no need to copy anything.")
+endif()
 
 #----------------------------------------------------------------------------
 # For internal Geant4 use - but has no effect if you build this

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -61,7 +61,7 @@ ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh  ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o
 
 shared: $(ROOTSRC) $(ROOTOBJS) 
 	g++ -shared -O $(ROOTOBJS) -o $(ROOTSO) $(ROOTLIBS)
@@ -102,7 +102,8 @@ clean::
 	
 include $(G4INSTALL)/config/binmake.gmk
 
-# objects += $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
+$(G4TMPDIR)/obj.last: $(objects) $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
+	@$(TOUCH) $@ # touch the versioning file
 
 $(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -102,8 +102,7 @@ clean::
 	
 include $(G4INSTALL)/config/binmake.gmk
 
-$(G4TMPDIR)/obj.last: $(objects) $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
-	@$(TOUCH) $@ # touch the versioning file
+$(G4TMPDIR)/obj.last: $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
 
 $(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -61,7 +61,7 @@ ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh  ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o
 
 shared: $(ROOTSRC) $(ROOTOBJS) 
 	g++ -shared -O $(ROOTOBJS) -o $(ROOTSO) $(ROOTLIBS)
@@ -102,7 +102,7 @@ clean::
 	
 include $(G4INSTALL)/config/binmake.gmk
 
-objects += $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
+# objects += $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
 
 $(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -17,7 +17,7 @@ ROOTCFLAGS   := $(shell root-config --cflags) -DUSE_ROOT -fPIC
 ROOTLIBS     := $(shell root-config --libs)
 
 #LIBNAME := /home/bquilain/nuPRISM/WCSim/WCSim
-LIBNAME := ./WCSim
+LIBNAME := WCSim
 
 # NOTE: Geant4.7.0 changes the way Maximum Step size is defined.  
 # We need extra code for versions 4.7.0 and above; eventually 
@@ -36,7 +36,7 @@ ifdef GCCVERS296
 CPPFLAGS += -DUSE_STRSTREAM
 endif
 
-#CPPFLAGS  += -I$(ROOTSYS)/include $(ROOTCFLAGS) -std=c++0x -std=c++11           ##for unordered_map 
+#CPPFLAGS  += -I$(ROOTSYS)/include $(ROOTCFLAGS) -std=c++0x           ##for unordered_map 
 CPPFLAGS  += -I$(ROOTSYS)/include $(ROOTCFLAGS) -std=c++11           ##for unordered_map 
 EXTRALIBS += $(ROOTLIBS)
 
@@ -53,11 +53,11 @@ endif
 CPPFLAGS += -DGIT_HASH=\"$(shell git describe --always --long --tags --dirty)\"
 
 .PHONY: all
-all: rootcint shared libWCSim.a movedict lib bin 
+all: rootcint movedict shared libWCSim.a lib bin
 
 # Note dependencies not yet set up right yet
 
-ROOTSO    := ./libWCSimRoot.so
+ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh  ./include/WCSimRootLinkDef.hh
 
@@ -70,16 +70,13 @@ libWCSim.a : $(ROOTOBJS)
 	$(RM) $@
 	ar clq $@ $(ROOTOBJS) 
 
-./src/WCSimRootDict.cc : $(ROOTSRC)
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootTools.hh WCSimRootLinkDef.hh
+./WCSimRootDict.cxx : $(ROOTSRC)
+	rootcint  -f ./WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootTools.hh WCSimRootLinkDef.hh
 
-rootcint: ./src/WCSimRootDict.cc
+rootcint: ./WCSimRootDict.cxx
 
 movedict: rootcint
-ifneq (,$(wildcard ./src/WCSimRootDict_rdict.pcm))
-	cp -f ./src/WCSimRootDict_rdict.pcm .
-	cp -f ./src/WCSimRootDict_rdict.pcm ${G4WORKDIR}/tmp/${G4SYSTEM}/WCSim/
-endif
+	  if [ -f "./WCSimRootDict_rdict.pcm" ]; then cp -f ./WCSimRootDict_rdict.pcm ${G4WORKDIR}/tmp/${G4SYSTEM}/WCSim/; fi
 
 doxy:
 	@if [ ${DOXYGEN_EXISTS} = 1 ]; \
@@ -91,7 +88,7 @@ doxy:
 
 clean_wcsim:
 	echo  $(G4WORKDIR); 
-	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ ./src/WCSimRootDict.h ./src/WCSimRootDict.cc ./src/WCSimRootDict_rdict.pcm WCSimRootDict_rdict.pcm;
+	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ ./WCSimRootDict*
 	@if [ -d "doc/doxygen" ]; \
 		then \
 		rm -r doc/doxygen; \
@@ -100,11 +97,12 @@ clean_wcsim:
 #Clean with :: will be executed before the normal G4 clean
 #RootDict may lead to some troubles if not clean before checking dependencies
 clean::
-	@echo "Cleaning RootDict ..."
-	@rm -f ./WCSimRootDict.*
-	@rm -f ./src/WCSimRootDict.h ./src/WCSimRootDict.cc ./src/WCSimRootDict_rdict.pcm WCSimRootDict_rdict.pcm
+	@echo "Cleaning RootDict and libWCSim ..."
+	@rm -f ./WCSimRootDict* libWCSim*
 	
 include $(G4INSTALL)/config/binmake.gmk
+
+objects += $(G4TMPDIR)/WCSimRootDict.o # needed for the "lib" target
 
 $(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -26,7 +26,7 @@ ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh  ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o
 
 
 

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -24,10 +24,9 @@ G4TMPDIR := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim
 
 ROOTSO    := libWCSimRoot.so
 
-ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh ./include/WCSimRootLinkDef.hh
+ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh  ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSim
-
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
 
 
 
@@ -48,7 +47,7 @@ libWCSimRoot.so : $(ROOTOBJS)
 
 ./WCSimRootDict.cxx : $(ROOTSRC)
 	@echo Compiling rootcint ...
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootTools.hh WCSimRootLinkDef.hh
+	rootcint  -f ./WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootTools.hh WCSimRootLinkDef.hh
 
 rootcint: ./WCSimRootDict.cxx
 
@@ -66,6 +65,5 @@ $(G4TMPDIR)/%.o: %.cxx
 
 clean :
 	@rm -f $(G4TMPDIR)/*.o
-	@rm -f ./WCSimRootDict.*
-	@rm -f ./src/WCSimRootDict.h ./src/WCSimRootDict.cc ./src/WCSimRootDict_rdict.pcm WCSimRootDict_rdict.pcm
+	@rm -f ./WCSimRootDict*
 

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -26,7 +26,7 @@ ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./src/TJNuBeamFlux.cc ./include/TJNuBeamFlux.hh ./src/TNRooTrackerVtx.cc ./include/TNRooTrackerVtx.hh ./src/WCSimRootTools.cc ./include/WCSimRootTools.hh  ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TNRooTrackerVtx.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/TJNuBeamFlux.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootTools.o
 
 
 

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -81,7 +81,11 @@ int main(int argc,char** argv)
 
   // Currently, default physics list is set to FTFP_BERT
   // The custom WCSim physics list option is removed in versions later than WCSim1.6.0
-  char * WCSIMDIR = getenv("WCSIMDIR");
+  const char *WCSIMDIR = std::getenv("WCSIMDIR");
+  if (!(WCSIMDIR && WCSIMDIR[0])) { // make sure it's non-empty
+    WCSIMDIR = "."; // the "default" value
+    G4cout << "Note: WCSIMDIR not set, assuming: " << WCSIMDIR << G4endl;
+  }
   G4cout << "B.Q: Read" << Form("/control/execute %s/macros/jobOptions.mac",WCSIMDIR) << G4endl;
   file_exists(Form("%s/macros/jobOptions.mac",WCSIMDIR));
   UI->ApplyCommand(Form("/control/execute %s/macros/jobOptions.mac",WCSIMDIR));

--- a/make_sukap_ROOT5.sh
+++ b/make_sukap_ROOT5.sh
@@ -16,7 +16,7 @@ if [ ! -d ${build_directory} ]; then
 	if [ -d ${G4WORKDIR} ]; then
 		rm -r ${G4WORKDIR}
 	fi
-	rm *.o *.a *.so *~ */*~ src/*Dict*
+	rm *.o *.a *.so *~ */*~ *Dict*
 	
 	echo "Creating build directory ${build_directory}"
 	mkdir -p ${build_directory}

--- a/make_sukap_ROOT6.sh
+++ b/make_sukap_ROOT6.sh
@@ -16,7 +16,7 @@ if [ ! -d ${build_directory} ]; then
 	if [ -d ${G4WORKDIR} ]; then
 		rm -r ${G4WORKDIR}
 	fi
-	rm *.o *.a *.so *~ */*~ src/*Dict*
+	rm *.o *.a *.so *~ */*~ *Dict*
 	
 	echo "Creating build directory ${build_directory}"
 	mkdir -p ${build_directory}


### PR DESCRIPTION
* Both building methods, the one using GNU make and the other one using CMake, should create ROOT dictionaries with the ".cxx" file extension (up to now, the first method was creating a ".cc" file). These automatically created source code files should not pollute the "src/" directory (following the general ROOT rules, they should be created in the current "build" directory).
* Copy all required files to the "external" build directory when the CMake building method is used.
* Protect `WCSim.cc` against undefined `WCSIMDIR`.